### PR TITLE
docs: Add documentation for conda python

### DIFF
--- a/Exercise-1/RANSAC.py
+++ b/Exercise-1/RANSAC.py
@@ -3,6 +3,13 @@ import pcl
 
 # Load Point Cloud file
 cloud = pcl.load_XYZRGB('tabletop.pcd')
+# For students using Python 2.7 with Anaconda,
+# PCL module can be installed from https://anaconda.org/ccordoba12/python-pcl
+# And the documentation as follows:
+# http://strawlab.github.io/python-pcl/
+# In that case, update the code above to:
+# cloud = pcl.PointCloud()
+# cloud.from_file('tabletop.pcd')
 
 
 # Voxel Grid filter


### PR DESCRIPTION
PCL module that is currently supported in Anaconda does not support `load_XYZRGB()` function.